### PR TITLE
Add support for /beta version Microsoft Graph

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ bld/
 
 # test .Net Interactive notebook
 *.ipynb
+!demo.ipynb

--- a/demo.ipynb
+++ b/demo.ipynb
@@ -130,7 +130,7 @@
    },
    "outputs": [],
    "source": [
-    "var me = await interactiveClient.Me.Request().GetAsync();\n",
+    "var me = await interactiveClient.Me.GetAsync();\n",
     "me.DisplayName"
    ]
   },
@@ -181,7 +181,7 @@
    },
    "outputs": [],
    "source": [
-    "var me = await deviceCodeClient.Me.Request().GetAsync();\n",
+    "var me = await deviceCodeClient.Me.GetAsync();\n",
     "me.DisplayName"
    ]
   },
@@ -233,11 +233,11 @@
    "outputs": [],
    "source": [
     "var users = await appOnlyClient.Users\n",
-    "    .Request()\n",
-    "    .Select(u => new {u.DisplayName, u.Mail})\n",
-    "    .GetAsync();\n",
+    "    .GetAsync(requestConfiguration => {\n",
+    "        requestConfiguration.QueryParameters.Select = new string[] { \"DisplayName\", \"UserPrincipalName\" };\n",
+    "    });\n",
     "\n",
-    "users.Select(u => new {u.DisplayName, u.Mail})"
+    "users.Value.Select(u => new {u.DisplayName, u.UserPrincipalName})"
    ]
   }
  ],

--- a/demo.ipynb
+++ b/demo.ipynb
@@ -1,0 +1,261 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    }
+   },
+   "source": [
+    "# .NET Interactive with Microsoft Graph\n",
+    "\n",
+    "This file demonstrates using the Microsoft Graph extension for .NET Interactive Notebooks.\n",
+    "\n",
+    "## Build and load\n",
+    "\n",
+    "In the following sections, replace `<REPLACE_WITH_WORKING_DIRECTORY>` with your current working directory for project."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "pwsh"
+    },
+    "vscode": {
+     "languageId": "dotnet-interactive.pwsh"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "rm ~/.nuget/packages/Microsoft.DotNet.Interactive.MicrosoftGraph -Force -Recurse -ErrorAction Ignore\n",
+    "dotnet build ./src/Microsoft.DotNet.Interactive.MicrosoftGraph.csproj"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "vscode": {
+     "languageId": "dotnet-interactive.csharp"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "#i nuget:<REPLACE_WITH_WORKING_DIRECTORY>\\src\\bin\\Debug\\\n",
+    "#r \"nuget:Microsoft.DotNet.Interactive.MicrosoftGraph,*-*\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Add your app registration\n",
+    "\n",
+    "In the following sections, replace `YOUR_CLIENT_ID` with your client ID, `YOUR_TENANT_ID` with your tenant ID, and `YOUR_CLIENT_SECRET` with your client secret (if you're using client credential authentication)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Help"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "vscode": {
+     "languageId": "dotnet-interactive.csharp"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "#!microsoftgraph -h"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Interactive browser auth\n",
+    "\n",
+    "Interactive browser auth (via [authorization code flow](https://learn.microsoft.com/azure/active-directory/develop/v2-oauth2-auth-code-flow)) should work for user authentication on systems where a browser is available.\n",
+    "\n",
+    "### Create client"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "vscode": {
+     "languageId": "dotnet-interactive.csharp"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "#!microsoftgraph -t \"YOUR_TENANT_ID\" -c \"YOUR_CLIENT_ID\" -a InteractiveBrowser -n interactiveClient"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Make requests"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "vscode": {
+     "languageId": "dotnet-interactive.csharp"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "var me = await interactiveClient.Me.Request().GetAsync();\n",
+    "me.DisplayName"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Device code auth\n",
+    "\n",
+    "[Device code auth](https://learn.microsoft.com/azure/active-directory/develop/v2-oauth2-device-code) is designed for user authentication on systems that do not have a default browser available.\n",
+    "\n",
+    "### Create client"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "vscode": {
+     "languageId": "dotnet-interactive.csharp"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "#!microsoftgraph -t \"YOUR_TENANT_ID\" -c \"YOUR_CLIENT_ID\" -a DeviceCode -n deviceCodeClient"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Make requests"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "vscode": {
+     "languageId": "dotnet-interactive.csharp"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "var me = await deviceCodeClient.Me.Request().GetAsync();\n",
+    "me.DisplayName"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Client credential auth\n",
+    "\n",
+    "[Client credential auth](https://learn.microsoft.com/azure/active-directory/develop/v2-oauth2-client-creds-grant-flow) is designed for unattended scenarios. In this case, a user is not authenticated - the application itself is authenticated. This auth flow does require a tenant admin to provide consent.\n",
+    "\n",
+    "### Create client"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "vscode": {
+     "languageId": "dotnet-interactive.csharp"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "#!microsoftgraph -t \"YOUR_TENANT_ID\" -c \"YOUR_CLIENT_ID\" -s \"YOUR_CLIENT_SECRET\" -a ClientCredential -n appOnlyClient"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Make requests"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "vscode": {
+     "languageId": "dotnet-interactive.csharp"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "var users = await appOnlyClient.Users\n",
+    "    .Request()\n",
+    "    .Select(u => new {u.DisplayName, u.Mail})\n",
+    "    .GetAsync();\n",
+    "\n",
+    "users.Select(u => new {u.DisplayName, u.Mail})"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".NET (C#)",
+   "language": "C#",
+   "name": ".net-csharp"
+  },
+  "language_info": {
+   "file_extension": ".cs",
+   "mimetype": "text/x-csharp",
+   "name": "C#",
+   "pygments_lexer": "csharp",
+   "version": "9.0"
+  },
+  "orig_nbformat": 4
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/src/ApiVersion.cs
+++ b/src/ApiVersion.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.DotNet.Interactive.MicrosoftGraph
+{
+    /// <summary>
+    /// Microsoft Graph API versions.
+    /// </summary>
+    public enum ApiVersion
+    {
+        /// <summary>
+        /// Microsoft Graph V1 version.
+        /// </summary>
+        V1,
+
+        /// <summary>
+        /// Microsoft Graph Beta version.
+        /// </summary>
+        Beta,
+    }
+}

--- a/src/BaseUrl.cs
+++ b/src/BaseUrl.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+
+namespace Microsoft.DotNet.Interactive.MicrosoftGraph
+{
+    /// <summary>
+    /// Helper class to set BaseUrl for Microsoft Graph service root endpoint.
+    /// </summary>
+    public class BaseUrl
+    {
+        /// <summary>
+        /// Gets the BaseUrl for Microsoft Graph service root endpoint based on national cloud and API version.
+        /// </summary>
+        /// <param name="nationalCloud">The national cloud for Microsoft Graph service root endpoint.</param>
+        /// <param name="apiVersion">The API version for Microsoft Graph service root endpoint.</param>
+        /// <returns>The requested BaseUrl for Microsoft Graph service root endpoint.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">The requested national cloud and API Version pair was invalid.</exception>
+        public static string GetBaseUrl(
+            NationalCloud nationalCloud, ApiVersion apiVersion) => (nationalCloud, apiVersion) switch
+            {
+                (NationalCloud.Global, ApiVersion.V1) => new string("https://graph.microsoft.com/v1.0"),
+                (NationalCloud.Global, ApiVersion.Beta) => new string("https://graph.microsoft.com/beta"),
+                (NationalCloud.USGov, ApiVersion.V1) => new string("https://graph.microsoft.us/v1.0"),
+                (NationalCloud.USGov, ApiVersion.Beta) => new string("https://graph.microsoft.us/beta"),
+                (NationalCloud.USGovDoD, ApiVersion.V1) => new string("https://dod-graph.microsoft.us/v1.0"),
+                (NationalCloud.USGovDoD, ApiVersion.Beta) => new string("https://dod-graph.microsoft.us/beta"),
+                _ => throw new ArgumentOutOfRangeException(
+                    nameof(nationalCloud),
+                    nameof(apiVersion),
+                    $"Unexpected nationalCloud and apiVersion pair values: {nationalCloud}, {apiVersion}"),
+            };
+    }
+}

--- a/src/Microsoft.DotNet.Interactive.MicrosoftGraph.csproj
+++ b/src/Microsoft.DotNet.Interactive.MicrosoftGraph.csproj
@@ -23,9 +23,10 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.7.0" />
-    <PackageReference Include="microsoft.dotnet.interactive" Version="1.0.0-beta.22452.2" />
-    <PackageReference Include="microsoft.dotnet.interactive.csharp" Version="1.0.0-beta.22452.2" />
-    <PackageReference Include="Microsoft.Graph" Version="4.42.0" />
+    <PackageReference Include="microsoft.dotnet.interactive" Version="1.0.0-beta.22504.6" />
+    <PackageReference Include="microsoft.dotnet.interactive.csharp" Version="1.0.0-beta.22504.6" />
+    <!-- <PackageReference Include="Microsoft.Graph" Version="4.42.0" /> -->
+    <PackageReference Include="Microsoft.Graph.Beta" Version="5.12.0-preview" />
     <PackageReference Include="MinVer" Version="4.2.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
@@ -39,4 +40,12 @@
   <ItemGroup>
     <None Include="$(OutputPath)/Microsoft.DotNet.Interactive.MicrosoftGraph.dll" Pack="true" PackagePath="interactive-extensions/dotnet" />
   </ItemGroup>
+
+  <Target Name="ChangeAliasesOfStrongNameAssemblies" BeforeTargets="FindReferenceAssembliesForReferences;ResolveReferences">
+    <ItemGroup>
+      <ReferencePath Condition="'%(FileName)' == 'Microsoft.Graph.Beta'">
+        <Aliases>BetaLib</Aliases>
+      </ReferencePath>
+    </ItemGroup>
+  </Target>
 </Project>

--- a/src/Microsoft.DotNet.Interactive.MicrosoftGraph.csproj
+++ b/src/Microsoft.DotNet.Interactive.MicrosoftGraph.csproj
@@ -23,10 +23,11 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.7.0" />
-    <PackageReference Include="microsoft.dotnet.interactive" Version="1.0.0-beta.22504.6" />
-    <PackageReference Include="microsoft.dotnet.interactive.csharp" Version="1.0.0-beta.22504.6" />
-    <!-- <PackageReference Include="Microsoft.Graph" Version="4.42.0" /> -->
-    <PackageReference Include="Microsoft.Graph.Beta" Version="5.12.0-preview" />
+    <PackageReference Include="microsoft.dotnet.interactive" Version="1.0.0-beta.22553.7" />
+    <PackageReference Include="microsoft.dotnet.interactive.csharp" Version="1.0.0-beta.22553.7" />
+    <PackageReference Include="Microsoft.Graph" Version="4.46.0" />
+    <!-- <PackageReference Include="Microsoft.Graph.Beta" Version="4.64.0-preview" /> -->
+    <PackageReference Include="Microsoft.Graph.Beta" Version="5.13.0-preview" />
     <PackageReference Include="MinVer" Version="4.2.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/src/Microsoft.DotNet.Interactive.MicrosoftGraph.csproj
+++ b/src/Microsoft.DotNet.Interactive.MicrosoftGraph.csproj
@@ -25,8 +25,7 @@
     <PackageReference Include="Azure.Identity" Version="1.7.0" />
     <PackageReference Include="microsoft.dotnet.interactive" Version="1.0.0-beta.22553.7" />
     <PackageReference Include="microsoft.dotnet.interactive.csharp" Version="1.0.0-beta.22553.7" />
-    <PackageReference Include="Microsoft.Graph" Version="4.46.0" />
-    <!-- <PackageReference Include="Microsoft.Graph.Beta" Version="4.64.0-preview" /> -->
+    <PackageReference Include="Microsoft.Graph" Version="5.0.0-preview.13" />
     <PackageReference Include="Microsoft.Graph.Beta" Version="5.13.0-preview" />
     <PackageReference Include="MinVer" Version="4.2.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/MicrosoftGraphKernelExtension.cs
+++ b/src/MicrosoftGraphKernelExtension.cs
@@ -75,18 +75,9 @@ public class MicrosoftGraphKernelExtension : IKernelExtension
             {
                 var tokenCredential = CredentialProvider.GetTokenCredential(
                     authenticationFlow, tenantId, clientId, clientSecret, nationalCloud);
+
                 var graphServiceClient = new Beta.GraphServiceClient(tokenCredential, Scopes.GetScopes(nationalCloud));
-                switch (nationalCloud)
-                {
-                    case NationalCloud.USGov:
-                        //graphServiceClient.BaseUrl = "https://graph.microsoft.us/v1.0";
-                        break;
-                    case NationalCloud.USGovDoD:
-                        //graphServiceClient.BaseUrl = "https://dod-graph.microsoft.us/v1.0";
-                        break;
-                    default:
-                        break;
-                }
+                graphServiceClient.RequestAdapter.BaseUrl = BaseUrl.GetBaseUrl(nationalCloud, apiVersion);
 
                 await cSharpKernel.SetValueAsync(scopeName, graphServiceClient, typeof(Beta.GraphServiceClient));
                 KernelInvocationContextExtensions.Display(KernelInvocationContext.Current, $"Graph client declared with name: {scopeName}");

--- a/src/MicrosoftGraphKernelExtension.cs
+++ b/src/MicrosoftGraphKernelExtension.cs
@@ -80,9 +80,9 @@ public class MicrosoftGraphKernelExtension : IKernelExtension
                 switch (apiVersion)
                 {
                     case ApiVersion.V1:
-                        // var graphServiceClient = new GraphServiceClient(tokenCredential, Scopes.GetScopes(nationalCloud));
-                        // graphServiceClient.BaseUrl = BaseUrl.GetBaseUrl(nationalCloud, apiVersion);
-                        // await cSharpKernel.SetValueAsync(scopeName, graphServiceClient, typeof(GraphServiceClient));
+                        var graphServiceClient = new GraphServiceClient(tokenCredential, Scopes.GetScopes(nationalCloud));
+                        graphServiceClient.RequestAdapter.BaseUrl = BaseUrl.GetBaseUrl(nationalCloud, apiVersion);
+                        await cSharpKernel.SetValueAsync(scopeName, graphServiceClient, typeof(GraphServiceClient));
                         break;
                     case ApiVersion.Beta:
                         var graphServiceClientBeta = new Beta.GraphServiceClient(tokenCredential, Scopes.GetScopes(nationalCloud));

--- a/src/MicrosoftGraphKernelExtension.cs
+++ b/src/MicrosoftGraphKernelExtension.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.DotNet.Interactive.Commands;
 using Microsoft.DotNet.Interactive.CSharp;
+using Microsoft.Graph;
 using Beta = BetaLib.Microsoft.Graph.Beta;
 
 namespace Microsoft.DotNet.Interactive.MicrosoftGraph;
@@ -76,10 +77,22 @@ public class MicrosoftGraphKernelExtension : IKernelExtension
                 var tokenCredential = CredentialProvider.GetTokenCredential(
                     authenticationFlow, tenantId, clientId, clientSecret, nationalCloud);
 
-                var graphServiceClient = new Beta.GraphServiceClient(tokenCredential, Scopes.GetScopes(nationalCloud));
-                graphServiceClient.RequestAdapter.BaseUrl = BaseUrl.GetBaseUrl(nationalCloud, apiVersion);
+                switch (apiVersion)
+                {
+                    case ApiVersion.V1:
+                        // var graphServiceClient = new GraphServiceClient(tokenCredential, Scopes.GetScopes(nationalCloud));
+                        // graphServiceClient.BaseUrl = BaseUrl.GetBaseUrl(nationalCloud, apiVersion);
+                        // await cSharpKernel.SetValueAsync(scopeName, graphServiceClient, typeof(GraphServiceClient));
+                        break;
+                    case ApiVersion.Beta:
+                        var graphServiceClientBeta = new Beta.GraphServiceClient(tokenCredential, Scopes.GetScopes(nationalCloud));
+                        graphServiceClientBeta.RequestAdapter.BaseUrl = BaseUrl.GetBaseUrl(nationalCloud, apiVersion);
+                        await cSharpKernel.SetValueAsync(scopeName, graphServiceClientBeta, typeof(Beta.GraphServiceClient));
+                        break;
+                    default:
+                        break;
+                }
 
-                await cSharpKernel.SetValueAsync(scopeName, graphServiceClient, typeof(Beta.GraphServiceClient));
                 KernelInvocationContextExtensions.Display(KernelInvocationContext.Current, $"Graph client declared with name: {scopeName}");
             },
             tenantIdOption,


### PR DESCRIPTION
Add APIVersion as an enum and option on magic command.

Switch to v5 preview of Graph .Net SDK (from v4) as these implement Microsoft.Graph.Beta namespace which is helpful / needed for differentiating between /v1 and /beta packages and dependencies.

Update demo notebook to use v5 syntax for Graph .Net SDK.